### PR TITLE
add missing await and configure Bull queue parameters

### DIFF
--- a/src/development.controller.ts
+++ b/src/development.controller.ts
@@ -53,20 +53,20 @@ export class DevelopmentController {
   }
 
   @Post('queue/pause')
-  async pauseQueue() {
-    await this.graphUpdateQueue.pause();
+  pauseQueue() {
+    this.graphUpdateQueue.pause();
   }
 
   @Post('queue/resume')
-  async resumeQueue() {
-    await this.graphUpdateQueue.resume();
+  resumeQueue() {
+    this.graphUpdateQueue.resume();
   }
 
   @Post('queue/retry')
   async retryJob(@Param('jobId') jobId: string) {
     const job = await this.graphUpdateQueue.getJob(jobId);
     if (job) {
-      await job.retry();
+      job.retry();
     } else {
       throw new HttpException('Job ID not found', HttpStatus.NOT_FOUND);
     }
@@ -109,9 +109,14 @@ export class DevelopmentController {
   }
 
   @Post('scan/:blockNumber')
-  async scanChain(@Param('blockNumber') blockNumber: string) {
+  async scanChainFromBlock(@Param('blockNumber') blockNumber: string) {
     const block = BigInt(blockNumber) - 1n;
     await this.cacheManager.set(LAST_SEEN_BLOCK_NUMBER_KEY, block.toString());
+    this.scannerService.scan();
+  }
+
+  @Post('scan')
+  scanChain() {
     this.scannerService.scan();
   }
 }

--- a/src/processor/processor.module.ts
+++ b/src/processor/processor.module.ts
@@ -7,6 +7,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '#app/config/config.module';
 import { ConfigService } from '#app/config/config.service';
 import { BlockchainModule } from '#app/blockchain/blockchain.module';
+import { BackoffOptions } from 'bullmq';
 import { QueueConsumerService } from './queue-consumer.service';
 import { ReconnectionGraphService } from './reconnection-graph.service';
 import { GraphManagerModule } from '../graph/graph-state.module';
@@ -38,8 +39,12 @@ import { GraphStateManager } from '../graph/graph-state-manager';
     BullModule.registerQueue({
       name: 'graphUpdateQueue',
       defaultJobOptions: {
-        attempts: 3,
-        removeOnComplete: true,
+        attempts: 5,
+        backoff: {
+          type: 'exponential',
+        },
+        removeOnComplete: { count: 100 },
+        removeOnFail: { count: 5000 },
       },
     }),
     ConfigModule,

--- a/src/processor/queue-consumer.service.ts
+++ b/src/processor/queue-consumer.service.ts
@@ -26,9 +26,10 @@ export class QueueConsumerService extends WorkerHost {
     if (typeof job.data.debugDisposition !== 'undefined') {
       const debugData: any = job.data.debugDisposition;
       switch (debugData?.action) {
-        case 'abort':
-          this.logger.debug(`Forcing abort in order to generate stalled job: ${job.id}`);
-          process.exit(1);
+        // This is too dangerous to leave enabled unless you're doing serious debugging
+        // case 'abort':
+        //   this.logger.debug(`Forcing abort in order to generate stalled job: ${job.id}`);
+        //   process.exit(1);
 
         // eslint-disable-next-line no-fallthrough
         case 'fail':
@@ -51,6 +52,6 @@ export class QueueConsumerService extends WorkerHost {
       }
     }
 
-    this.graphSdkService.updateUserGraph(job.data.dsnpId, job.data.providerId, job.data.processTransitiveUpdates);
+    await this.graphSdkService.updateUserGraph(job.data.dsnpId, job.data.providerId, job.data.processTransitiveUpdates);
   }
 }


### PR DESCRIPTION
Closes #52 

* Adds missing `await` in queue processor that was causing application to abort on `unhandledPromiseRejection`
* Specifies better queue management defaults