### PR TITLE
Send txs without waiting and check tx success/failure in separate queue

### DIFF
--- a/src/blockchain/blockchain-constants.ts
+++ b/src/blockchain/blockchain-constants.ts
@@ -1,3 +1,4 @@
 export namespace BlockchainConstants {
   export const NUMBER_BLOCKS_TO_CRAWL = 32n; // TODO: take from tx, keeping it constant to default tx mortality
+  export const SECONDS_PER_BLOCK = 12;
 }

--- a/src/blockchain/blockchain-constants.ts
+++ b/src/blockchain/blockchain-constants.ts
@@ -1,29 +1,3 @@
 export namespace BlockchainConstants {
-  interface IExtrinsicCall {
-    pallet: string;
-    extrinsic: string;
-  }
-
-  interface IChainEvent {
-    eventPallet: string;
-    event: string;
-  }
-
-  interface IChainQuery {
-    queryPallet: string;
-    query: string;
-  }
-
-  interface IChainRpc {
-    rpcPallet: string;
-    rpc: string;
-  }
-
-  const PALLET_FREQ_TX_PYMT = 'frequencyTxPayment';
-  const PALLET_STATEFUL_STORAGE = 'statefulStorage';
-
-  const EX_PAY_CAPACITY_BATCH = 'payWithCapacityBatchAll';
-  const EX_UPSERT_PAGE = 'upsertPage';
-
-  const PAY_WITH_CAPACITY_BATCH: IExtrinsicCall = { pallet: PALLET_FREQ_TX_PYMT, extrinsic: EX_PAY_CAPACITY_BATCH };
+  export const NUMBER_BLOCKS_TO_CRAWL = 32n; // TODO: take from tx, keeping it constant to default tx mortality
 }

--- a/src/blockchain/blockchain.service.ts
+++ b/src/blockchain/blockchain.service.ts
@@ -5,9 +5,9 @@ import { ApiPromise, ApiRx, HttpProvider, WsProvider } from '@polkadot/api';
 import { firstValueFrom } from 'rxjs';
 import { options } from '@frequency-chain/api-augment';
 import { KeyringPair } from '@polkadot/keyring/types';
-import { BlockHash, BlockNumber, Index } from '@polkadot/types/interfaces';
+import { BlockHash, BlockNumber, DispatchError, Hash, Index, SignedBlock } from '@polkadot/types/interfaces';
 import { SubmittableExtrinsic } from '@polkadot/api/types';
-import { AnyNumber, ISubmittableResult } from '@polkadot/types/types';
+import { AnyNumber, ISubmittableResult, RegistryError } from '@polkadot/types/types';
 import { u32, Option, u128 } from '@polkadot/types';
 import { PalletCapacityCapacityDetails, PalletCapacityEpochInfo } from '@polkadot/types/lookup';
 import { Extrinsic } from './extrinsic';
@@ -138,5 +138,86 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
 
   public async getNonce(account: Uint8Array): Promise<Index> {
     return this.rpc('system', 'accountNextIndex', account);
+  }
+
+  public getBlock(block: BlockHash): Promise<SignedBlock> {
+    return firstValueFrom(this.api.rpc.chain.getBlock(block));
+  }
+
+  public async getLatestFinalizedBlockNumber(): Promise<bigint> {
+    return (await this.apiPromise.rpc.chain.getBlock()).block.header.number.toBigInt();
+  }
+
+  public async getLatestFinalizedBlockHash(): Promise<BlockHash> {
+    return (await this.apiPromise.rpc.chain.getFinalizedHead()) as BlockHash;
+  }
+
+  public async crawlBlockListForTx(
+    txHash: Hash,
+    blockList: bigint[],
+    successEvents: [{ pallet: string; event: string }],
+  ): Promise<{ found: boolean; success: boolean; blockHash?: BlockHash; capacityWithDrawn?: string; error?: RegistryError }> {
+    const txReceiptPromises: Promise<{ found: boolean; success: boolean; blockHash?: BlockHash; capacityWithDrawn?: string; error?: RegistryError }>[] = blockList.map(
+      async (blockNumber) => {
+        const blockHash = await this.getBlockHash(blockNumber);
+        const block = await this.getBlock(blockHash);
+        const txInfo = block.block.extrinsics.find((extrinsic) => extrinsic.hash.toString() === txHash.toString());
+
+        if (!txInfo) {
+          return { found: false, success: false };
+        }
+
+        this.logger.verbose(`Found tx ${txHash} in block ${blockNumber}`);
+        const at = await this.api.at(blockHash.toHex());
+        const eventsPromise = firstValueFrom(at.query.system.events());
+
+        let isTxSuccess = false;
+        let totalBlockCapacity: bigint = 0n;
+        let txError: RegistryError | undefined;
+
+        try {
+          const events = await eventsPromise;
+
+          events.forEach((record) => {
+            const { event } = record;
+            const eventName = event.section;
+            const { method } = event;
+            const { data } = event;
+            this.logger.debug(`Received event: ${eventName} ${method} ${data}`);
+
+            // find capacity withdrawn event
+            if (eventName.search('capacity') !== -1 && method.search('Withdrawn') !== -1) {
+              // allow lowercase constructor for eslint
+              // eslint-disable-next-line new-cap
+              const currentCapacity: u128 = new u128(this.api.registry, data[1]);
+              totalBlockCapacity += currentCapacity.toBigInt();
+            }
+
+            // check custom success events
+            if (successEvents.find((successEvent) => successEvent.pallet === eventName && successEvent.event === method)) {
+              this.logger.debug(`Found success event ${eventName} ${method}`);
+              isTxSuccess = true;
+            }
+
+            // check for system extrinsic failure
+            if (eventName.search('system') !== -1 && method.search('ExtrinsicFailed') !== -1) {
+              const dispatchError = data[0] as DispatchError;
+              const moduleThatErrored = dispatchError.asModule;
+              const moduleError = dispatchError.registry.findMetaError(moduleThatErrored);
+              txError = moduleError;
+              this.logger.error(`Extrinsic failed with error: ${JSON.stringify(moduleError)}`);
+            }
+          });
+        } catch (error) {
+          this.logger.error(error);
+        }
+        this.logger.debug(`Total capacity withdrawn in block: ${totalBlockCapacity.toString()}`);
+        return { found: true, success: isTxSuccess, blockHash, capacityWithDrawn: totalBlockCapacity.toString(), error: txError };
+      },
+    );
+    const results = await Promise.all(txReceiptPromises);
+    const result = results.find((receipt) => receipt.found);
+    this.logger.debug(`Found tx receipt: ${JSON.stringify(result)}`);
+    return result ?? { found: false, success: false };
   }
 }

--- a/src/development.controller.ts
+++ b/src/development.controller.ts
@@ -105,7 +105,7 @@ export class DevelopmentController {
 
   @Post('update/graph')
   updateGraph(@Body() payload: GraphUpdateJobDto) {
-    this.graphService.updateUserGraph(payload.dsnpId, payload.providerId, true);
+    this.graphService.updateUserGraph(payload.toGraphUpdateJob().key, payload.dsnpId, payload.providerId, true);
   }
 
   @Post('scan/:blockNumber')

--- a/src/interfaces/monitor.job.interface.ts
+++ b/src/interfaces/monitor.job.interface.ts
@@ -1,0 +1,8 @@
+import { BlockHash, Hash } from '@polkadot/types/interfaces';
+
+export interface ITxMonitorJob {
+  id: string;
+  txHash: Hash;
+  epoch: string;
+  lastFinalizedBlockHash: BlockHash;
+}

--- a/src/processor/graph.monitor.processor.service.ts
+++ b/src/processor/graph.monitor.processor.service.ts
@@ -52,7 +52,7 @@ export class GraphNotifierService extends WorkerHost {
             await this.reconnectionQueue.pause();
           }
           if (errorReport.retry) {
-            await this.retryRequestJob(job.data.referencePublishJob.toGraphUpdateJob().key);
+            await this.retryRequestJob(job.data.id);
           } else {
             throw new Error(`Job ${job.data.id} failed with error ${JSON.stringify(txResult.error)}`);
           }
@@ -60,7 +60,7 @@ export class GraphNotifierService extends WorkerHost {
 
         if (txResult.success) {
           this.logger.verbose(`Successfully found ${job.data.txHash} found in block ${txResult.blockHash}`);
-          await this.removeSuccessJobs(job.data.referencePublishJob.toGraphUpdateJob().key);
+          await this.removeSuccessJobs(job.data.id);
         }
       }
     } catch (e) {

--- a/src/processor/graph.monitor.processor.service.ts
+++ b/src/processor/graph.monitor.processor.service.ts
@@ -6,11 +6,9 @@ import Redis from 'ioredis';
 import { MILLISECONDS_PER_SECOND } from 'time-constants';
 import { RegistryError } from '@polkadot/types/types';
 import { BlockchainService } from '#app/blockchain/blockchain.service';
-import { ConfigService } from '#app/config/config.service';
 import { BlockchainConstants } from '#app/blockchain/blockchain-constants';
 import { ITxMonitorJob } from '#app/interfaces/monitor.job.interface';
-import { GraphUpdateJobDto } from '#app/interfaces/graph-update-job.dto';
-import { SECONDS_PER_BLOCK } from './queue-consumer.service';
+import { IGraphUpdateJob } from '#app/interfaces/graph-update-job.interface';
 
 @Injectable()
 @Processor('graphTxMonitorQueue')
@@ -76,7 +74,7 @@ export class GraphNotifierService extends WorkerHost {
 
   private async retryRequestJob(requestReferenceId: string): Promise<void> {
     this.logger.debug(`Retrying graph change request job ${requestReferenceId}`);
-    const requestJob: Job<GraphUpdateJobDto, any, string> | undefined = await this.reconnectionQueue.getJob(requestReferenceId);
+    const requestJob: Job<IGraphUpdateJob, any, string> | undefined = await this.reconnectionQueue.getJob(requestReferenceId);
     if (!requestJob) {
       this.logger.debug(`Job ${requestReferenceId} not found in queue`);
       return;
@@ -96,7 +94,7 @@ export class GraphNotifierService extends WorkerHost {
       const newEpochCapacity = epochCapacity + capacityWithdrew;
 
       const epochDurationBlocks = await this.blockchainService.getCurrentEpochLength();
-      const epochDuration = epochDurationBlocks * SECONDS_PER_BLOCK * MILLISECONDS_PER_SECOND;
+      const epochDuration = epochDurationBlocks * BlockchainConstants.SECONDS_PER_BLOCK * MILLISECONDS_PER_SECOND;
       await this.cacheManager.setex(epochCapacityKey, epochDuration, newEpochCapacity.toString());
     } catch (error) {
       this.logger.error(`Error setting epoch capacity: ${error}`);

--- a/src/processor/graph.monitor.processor.service.ts
+++ b/src/processor/graph.monitor.processor.service.ts
@@ -1,0 +1,139 @@
+import { InjectRedis } from '@liaoliaots/nestjs-redis';
+import { InjectQueue, Processor, WorkerHost } from '@nestjs/bullmq';
+import { Injectable, Logger } from '@nestjs/common';
+import { Job, Queue } from 'bullmq';
+import Redis from 'ioredis';
+import { MILLISECONDS_PER_SECOND } from 'time-constants';
+import { RegistryError } from '@polkadot/types/types';
+import { BlockchainService } from '#app/blockchain/blockchain.service';
+import { ConfigService } from '#app/config/config.service';
+import { BlockchainConstants } from '#app/blockchain/blockchain-constants';
+import { ITxMonitorJob } from '#app/interfaces/monitor.job.interface';
+import { GraphUpdateJobDto } from '#app/interfaces/graph-update-job.dto';
+import { SECONDS_PER_BLOCK } from './queue-consumer.service';
+
+@Injectable()
+@Processor('graphTxMonitorQueue')
+export class GraphNotifierService extends WorkerHost {
+  private logger: Logger;
+
+  constructor(
+    @InjectRedis() private cacheManager: Redis,
+    @InjectQueue('graphUpdateQueue') private reconnectionQueue: Queue,
+    private blockchainService: BlockchainService,
+  ) {
+    super();
+    this.logger = new Logger(this.constructor.name);
+  }
+
+  async process(job: Job<ITxMonitorJob, any, string>): Promise<any> {
+    this.logger.log(`Processing job ${job.id} of type ${job.name}`);
+    try {
+      const numberBlocksToParse = BlockchainConstants.NUMBER_BLOCKS_TO_CRAWL;
+      const txCapacityEpoch = job.data.epoch;
+      const previousKnownBlockNumber = (await this.blockchainService.getBlock(job.data.lastFinalizedBlockHash)).block.header.number.toBigInt();
+      const currentFinalizedBlockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
+      const blockList: bigint[] = [];
+
+      for (let i = previousKnownBlockNumber; i <= currentFinalizedBlockNumber && i < previousKnownBlockNumber + numberBlocksToParse; i += 1n) {
+        blockList.push(i);
+      }
+      const txResult = await this.blockchainService.crawlBlockListForTx(job.data.txHash, blockList, [{ pallet: 'system', event: 'ExtrinsicSuccess' }]);
+      if (!txResult.found) {
+        this.logger.error(`Tx ${job.data.txHash} not found in block list`);
+        throw new Error(`Tx ${job.data.txHash} not found in block list`);
+      } else {
+        // Set current epoch capacity
+        await this.setEpochCapacity(txCapacityEpoch, BigInt(txResult.capacityWithDrawn ?? 0n));
+        if (txResult.error) {
+          this.logger.debug(`Error found in tx result: ${JSON.stringify(txResult.error)}`);
+          const errorReport = await this.handleMessagesFailure(txResult.error);
+          if (errorReport.pause) {
+            await this.reconnectionQueue.pause();
+          }
+          if (errorReport.retry) {
+            await this.retryRequestJob(job.data.referencePublishJob.toGraphUpdateJob().key);
+          } else {
+            throw new Error(`Job ${job.data.id} failed with error ${JSON.stringify(txResult.error)}`);
+          }
+        }
+
+        if (txResult.success) {
+          this.logger.verbose(`Successfully found ${job.data.txHash} found in block ${txResult.blockHash}`);
+          await this.removeSuccessJobs(job.data.referencePublishJob.toGraphUpdateJob().key);
+        }
+      }
+    } catch (e) {
+      this.logger.error(e);
+      throw e;
+    }
+  }
+
+  private async removeSuccessJobs(referenceId: string): Promise<void> {
+    this.logger.debug(`Removing success jobs for ${referenceId}`);
+    this.reconnectionQueue.remove(referenceId);
+  }
+
+  private async retryRequestJob(requestReferenceId: string): Promise<void> {
+    this.logger.debug(`Retrying graph change request job ${requestReferenceId}`);
+    const requestJob: Job<GraphUpdateJobDto, any, string> | undefined = await this.reconnectionQueue.getJob(requestReferenceId);
+    if (!requestJob) {
+      this.logger.debug(`Job ${requestReferenceId} not found in queue`);
+      return;
+    }
+    await this.reconnectionQueue.remove(requestReferenceId);
+    await this.reconnectionQueue.add(`Retrying publish job - ${requestReferenceId}`, requestJob.data, {
+      jobId: requestReferenceId,
+    });
+  }
+
+  private async setEpochCapacity(epoch: string, capacityWithdrew: bigint): Promise<void> {
+    const epochCapacityKey = `epochCapacity:${epoch}`;
+
+    try {
+      const savedCapacity = await this.cacheManager.get(epochCapacityKey);
+      const epochCapacity = BigInt(savedCapacity ?? 0);
+      const newEpochCapacity = epochCapacity + capacityWithdrew;
+
+      const epochDurationBlocks = await this.blockchainService.getCurrentEpochLength();
+      const epochDuration = epochDurationBlocks * SECONDS_PER_BLOCK * MILLISECONDS_PER_SECOND;
+      await this.cacheManager.setex(epochCapacityKey, epochDuration, newEpochCapacity.toString());
+    } catch (error) {
+      this.logger.error(`Error setting epoch capacity: ${error}`);
+    }
+  }
+
+  private async handleMessagesFailure(moduleError: RegistryError): Promise<{ pause: boolean; retry: boolean }> {
+    try {
+      switch (moduleError.method) {
+        case 'StalePageState':
+        case 'ProofHasExpired':
+        case 'ProofNotYetValid':
+        case 'InvalidSignature':
+          // Re-try the job in the request change queue
+          return { pause: false, retry: true };
+        case 'InvalidSchemaId':
+          return { pause: true, retry: false };
+        case 'InvalidMessageSourceAccount':
+        case 'UnauthorizedDelegate':
+        case 'CorruptedState':
+        case 'InvalidItemAction':
+        case 'PageIdExceedsMaxAllowed':
+        case 'PageExceedsMaxPageSizeBytes':
+        case 'UnsupportedOperationForSchema':
+        case 'InvalidPayloadLocation':
+        case 'SchemaPayloadLocationMismatch':
+          // fail the job since this is unrecoverable
+          return { pause: false, retry: false };
+        default:
+          this.logger.error(`Unknown module error ${moduleError}`);
+          break;
+      }
+    } catch (error) {
+      this.logger.error(`Error handling module error: ${error}`);
+    }
+
+    // unknown error, pause the queue
+    return { pause: false, retry: false };
+  }
+}

--- a/src/processor/processor.module.ts
+++ b/src/processor/processor.module.ts
@@ -12,6 +12,7 @@ import { BullBoardModule } from '@bull-board/nestjs';
 import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
 import { ExpressAdapter } from '@bull-board/express';
 import { QueueConsumerService } from './queue-consumer.service';
+import { GraphNotifierService } from './graph.monitor.processor.service';
 import { ReconnectionGraphService } from './reconnection-graph.service';
 import { GraphManagerModule } from '../graph/graph-state.module';
 import { GraphStateManager } from '../graph/graph-state-manager';
@@ -75,12 +76,16 @@ import { NonceService } from './nonce.service';
       name: 'graphUpdateQueue',
       adapter: BullMQAdapter,
     }),
+    BullBoardModule.forFeature({
+      name: 'graphTxMonitorQueue',
+      adapter: BullMQAdapter,
+    }),
     ConfigModule,
     GraphManagerModule,
     BlockchainModule,
   ],
   controllers: [],
-  providers: [QueueConsumerService, ReconnectionGraphService, GraphStateManager, ProviderWebhookService, NonceService],
+  providers: [QueueConsumerService, GraphNotifierService, ReconnectionGraphService, GraphStateManager, ProviderWebhookService, NonceService],
   exports: [ReconnectionGraphService, BullModule],
 })
 export class ProcessorModule {}

--- a/src/processor/processor.module.ts
+++ b/src/processor/processor.module.ts
@@ -51,11 +51,21 @@ import { NonceService } from './nonce.service';
         backoff: {
           type: 'exponential',
         },
+        removeOnComplete: false,
+        removeOnFail: false,
+      },
+    }),
+    BullModule.registerQueue({
+      name: 'graphTxMonitorQueue',
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: {
+          type: 'exponential',
+        },
         removeOnComplete: true,
         removeOnFail: false,
       },
     }),
-
     // Bullboard UI
     BullBoardModule.forRoot({
       route: '/queues',

--- a/src/processor/reconnection-graph.service.ts
+++ b/src/processor/reconnection-graph.service.ts
@@ -427,7 +427,7 @@ export class ReconnectionGraphService {
       );
       const nonce = await this.nonceService.getNextNonce();
       this.logger.debug(`Capacity Wrapped Extrinsic: ${ext}, nonce:${nonce}`);
-      const [txHash, _] = await ext.signAndSend(nonce);
+      const [txHash, _] = await ext.signAndSendNoWait(nonce);
       if (!txHash) {
         throw new Error('Tx hash is undefined');
       }

--- a/src/processor/reconnection-graph.service.ts
+++ b/src/processor/reconnection-graph.service.ts
@@ -11,6 +11,10 @@ import { KeyringPair } from '@polkadot/keyring/types';
 import { hexToU8a } from '@polkadot/util';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Option, Vec } from '@polkadot/types';
+import { Hash } from '@polkadot/types/interfaces';
+import { ITxMonitorJob } from '#app/interfaces/monitor.job.interface';
+import { MILLISECONDS_PER_SECOND } from 'time-constants';
+import { BlockchainConstants } from '#app/blockchain/blockchain-constants';
 import { SkipTransitiveGraphs, createGraphUpdateJob } from '../interfaces/graph-update-job.interface';
 import { BlockchainService } from '../blockchain/blockchain.service';
 import { createKeys } from '../blockchain/create-keys';
@@ -30,6 +34,7 @@ export class ReconnectionGraphService {
     private configService: ConfigService,
     private graphStateManager: GraphStateManager,
     @InjectQueue('graphUpdateQueue') private graphUpdateQueue: Queue,
+    @InjectQueue('graphTxMonitorQueue') private graphTxMonitorQueue: Queue,
     private blockchainService: BlockchainService,
     private providerWebhookService: ProviderWebhookService,
     private eventEmitter: EventEmitter2,
@@ -42,14 +47,14 @@ export class ReconnectionGraphService {
     return this.blockchainService.api.consts.frequencyTxPayment.maximumCapacityBatchLength.toNumber();
   }
 
-  public async updateUserGraph(dsnpUserStr: string, providerStr: string, updateConnections: boolean): Promise<{ [key: string]: bigint }> {
+  public async updateUserGraph(jobId: string, dsnpUserStr: string, providerStr: string, updateConnections: boolean): Promise<any> {
     this.logger.debug(`Updating graph for user ${dsnpUserStr}, provider ${providerStr}`);
     // Acquire a graph state for the job
     const graphState = this.graphStateManager.createGraphState();
-
+    const lastFinalizedBlockHash = await this.blockchainService.getLatestFinalizedBlockHash();
+    const currentCapacityEpoch = await this.blockchainService.getCurrentCapacityEpoch();
     const dsnpUserId: MessageSourceId = this.blockchainService.api.registry.createType('MessageSourceId', dsnpUserStr);
     const providerId: ProviderId = this.blockchainService.api.registry.createType('ProviderId', providerStr);
-    const { key: jobIdNT, data: dataNT } = createGraphUpdateJob(dsnpUserId, providerId, SkipTransitiveGraphs);
 
     let graphConnections: ProviderGraph[] = [];
     let graphKeyPairs: ProviderKeyPair[] = [];
@@ -84,60 +89,40 @@ export class ReconnectionGraphService {
       const exportedUpdates = graphState.exportUserGraphUpdates(dsnpUserId.toString());
 
       const providerKeys = createKeys(this.configService.getProviderAccountSeedPhrase());
-
-      let batch: SubmittableExtrinsic<'rxjs', ISubmittableResult>[] = [];
-      let batchItemCount = 0;
-      let batchCount = 0;
-      const batches: SubmittableExtrinsic<'rxjs', ISubmittableResult>[][] = [];
-      exportedUpdates.forEach((bundle) => {
+      const blockDelay = BlockchainConstants.SECONDS_PER_BLOCK * MILLISECONDS_PER_SECOND;
+      let statefulStorageTxHash: Hash;
+      let txMonitorJob: ITxMonitorJob;
+      let tx: SubmittableExtrinsic<'rxjs', ISubmittableResult>;
+      // eslint-disable-next-line no-restricted-syntax
+      for (const bundle of exportedUpdates) {
         switch (bundle.type) {
           case 'PersistPage':
-            batch.push(
-              this.blockchainService.createExtrinsicCall(
-                { pallet: 'statefulStorage', extrinsic: 'upsertPage' },
-                bundle.ownerDsnpUserId,
-                bundle.schemaId,
-                bundle.pageId,
-                bundle.prevHash,
-                Array.from(Array.prototype.slice.call(bundle.payload)),
-              ),
+            tx = this.blockchainService.createExtrinsicCall(
+              { pallet: 'statefulStorage', extrinsic: 'upsertPage' },
+              bundle.ownerDsnpUserId,
+              bundle.schemaId,
+              bundle.pageId,
+              bundle.prevHash,
+              Array.from(Array.prototype.slice.call(bundle.payload)),
             );
-            batchItemCount += 1;
-            // If the batch size exceeds the capacityBatchLimit, send the batch to the chain
-            if (batchItemCount === this.capacityBatchLimit) {
-              // Reset the batch and count for the next batch
-              batches.push(batch);
-              batchCount += 1;
-              batch = [];
-              batchItemCount = 0;
-            }
+            // eslint-disable-next-line no-await-in-loop
+            statefulStorageTxHash = await this.processSingleBatch(providerKeys, tx);
+            txMonitorJob = {
+              id: jobId,
+              txHash: statefulStorageTxHash,
+              epoch: currentCapacityEpoch.toString(),
+              lastFinalizedBlockHash,
+            };
+            this.logger.debug(`Adding job to graph change notify queue: ${txMonitorJob.id}`);
+            this.graphTxMonitorQueue.add(`Graph Change Notify Job - ${txMonitorJob.id}`, txMonitorJob, {
+              delay: blockDelay,
+            });
             break;
-
           default:
             break;
         }
-      });
-
-      if (batch.length > 0) {
-        batches.push(batch);
       }
-      // eslint-disable-next-line no-await-in-loop
-      const totalCapacityUsed = await this.sendAndProcessChainEvents(dsnpUserId, providerKeys, batches);
-      // On successful export to chain, re-import the user's DSNP Graph from the blockchain and form import bundles
-      // import bundles are used to import the user's DSNP Graph into the graph SDK
-      // check if user graph exists in the graph SDK else queue a graph update job
-      // eslint-disable-next-line no-await-in-loop
-      const reImported = await this.importBundles(graphState, dsnpUserId, graphKeyPairs);
-      if (reImported) {
-        // eslint-disable-next-line no-await-in-loop
-        const userGraphExists = graphState.containsUserGraph(dsnpUserId.toString());
-        if (!userGraphExists) {
-          throw new Error(`User graph does not exist for ${dsnpUserId.toString()}`);
-        }
-      } else {
-        throw new Error(`Error re-importing bundles for ${dsnpUserId.toString()}`);
-      }
-      return totalCapacityUsed;
+      return {};
     } catch (err) {
       this.logger.error(`Error updating graph for user ${dsnpUserStr}, provider ${providerStr}: ${(err as Error).stack}`);
       throw err;
@@ -423,73 +408,34 @@ export class ReconnectionGraphService {
     return dsnpKeys;
   }
 
-  async sendAndProcessChainEvents(
-    dsnpUserId: MessageSourceId,
-    providerKeys: KeyringPair,
-    batchesMap: SubmittableExtrinsic<'rxjs', ISubmittableResult>[][],
-  ): Promise<{ [key: string]: bigint }> {
+  /**
+   * Processes a single batch by submitting a transaction to the blockchain.
+   *
+   * @param providerKeys The key pair used for signing the transaction.
+   * @param tx The transaction to be submitted.
+   * @returns The hash of the submitted transaction.
+   * @throws Error if the transaction hash is undefined or if there is an error processing the batch.
+   */
+  async processSingleBatch(providerKeys: KeyringPair, tx: SubmittableExtrinsic<'rxjs', ISubmittableResult>): Promise<Hash> {
+    this.logger.debug(`Submitting tx of size ${tx.length}, nonce:${tx.nonce}, method: ${tx.method.section}.${tx.method.method}`);
     try {
-      // iterate over batches and send them to the chain returning the capacity withdrawn
-      const totalCapUsedPerEpoch: {}[] = [];
-      this.logger.debug(`Processing ${batchesMap.length} batches for user ${dsnpUserId.toString()}`);
-      // eslint-disable-next-line no-restricted-syntax
-      for (const batch of batchesMap) {
-        // eslint-disable-next-line no-await-in-loop
-        const epoch = await this.processSingleBatch(dsnpUserId, providerKeys, batch);
-        totalCapUsedPerEpoch.push(epoch);
-      }
-      this.logger.debug(`Processed ${batchesMap.length} batches for user ${dsnpUserId.toString()}`);
-      if (totalCapUsedPerEpoch.length === 0) {
-        return {};
-      }
-      const totalCapacityUsed = totalCapUsedPerEpoch.reduce(
-        (acc, curr) => {
-          const epoch = Object.keys(curr)[0];
-          if (acc[epoch]) {
-            acc[epoch] += curr[epoch];
-          }
-          acc[epoch] = curr[epoch];
-          return acc;
-        },
-        {} as { [key: string]: bigint },
+      const ext = this.blockchainService.createExtrinsic(
+        { pallet: 'frequencyTxPayment', extrinsic: 'payWithCapacity' },
+        { eventPallet: 'frequencyTxPayment', event: 'CapacityPaid' },
+        providerKeys,
+        tx,
       );
-
-      return totalCapacityUsed;
-    } catch (e) {
-      this.logger.error(`Error processing batches for ${dsnpUserId.toString()}: ${e}`);
-      throw e;
-    }
-  }
-
-  async processSingleBatch(dsnpUserId: MessageSourceId, providerKeys: KeyringPair, batch: SubmittableExtrinsic<'rxjs', ISubmittableResult>[]): Promise<{ [key: string]: bigint }> {
-    this.logger.debug(`Submitting batch for user ${dsnpUserId.toString()}, batch length: ${batch.length}, batch: ${JSON.stringify(batch)}`);
-    try {
-      const currrentEpoch = await this.blockchainService.getCurrentCapacityEpoch();
       const nonce = await this.nonceService.getNextNonce();
-      const [event, eventMap] = await this.blockchainService
-        .createExtrinsic({ pallet: 'frequencyTxPayment', extrinsic: 'payWithCapacityBatchAll' }, { eventPallet: 'utility', event: 'BatchCompleted' }, providerKeys, batch)
-        .signAndSend(nonce);
-      if (!event || !this.blockchainService.api.events.utility.BatchCompleted.is(event)) {
-        // if we dont get code events, covering any unexpected connection errors
-        throw new Error(`Unexpected event received: ${JSON.stringify(event)}: re-trying to refresh graph state`);
+      this.logger.debug(`Capacity Wrapped Extrinsic: ${ext}, nonce:${nonce}`);
+      const [txHash, _] = await ext.signAndSend(nonce);
+      if (!txHash) {
+        throw new Error('Tx hash is undefined');
       }
-      const capacityWithDrawn = BigInt(eventMap['capacity.CapacityWithdrawn'].data[1].toString());
-      this.logger.debug(`Batch submitted for user ${dsnpUserId.toString()}`);
-      this.logger.debug(`Capacity withdrawn for user ${dsnpUserId.toString()}: ${capacityWithDrawn}`);
-      return { [currrentEpoch.toString()]: capacityWithDrawn };
-    } catch (e: any) {
-      this.logger.error(`Error processing batch for ${dsnpUserId.toString()}: ${e}`);
-      // Following errors includes are checked against
-      // 1. Inability to pay some fees`
-      // 2. Transaction is not valid due to `Target page hash does not match current page hash`
-      if (e instanceof Error && e.message.includes('Inability to pay some fees')) {
-        throw new errors.CapacityLowError(e.message);
-      } else if (e instanceof Error && e.message.includes('Target page hash does not match current page hash')) {
-        throw new errors.StaleHashError(e.message);
-      }
-      /// any errors we dont recognize, such as bad schema_id, etc
-      /// in such cases we should not retry the job
-      throw new errors.UnknownError(e as Error);
+      this.logger.debug(`Tx hash: ${txHash}`);
+      return txHash;
+    } catch (error: any) {
+      this.logger.error(`Error processing batch: ${error}`);
+      throw error;
     }
   }
 }


### PR DESCRIPTION
## Details

- Update queue consumer service to simply send the txs so many graph change txs can be included in same block
- A new queue process `graphTxMonitorQueue` will recieve info about submitted txs with a block delay
- Process above crawls through block lists to look for txs
- If tx is successful, do nothing and cleanup queues for successful job
- If tx fails on chain, primarily due to stalehash, retry the failure job 