### PR TITLE
Redis Disconnect Timeout now will exit(1)

### DIFF
--- a/src/cache/cache-utils.ts
+++ b/src/cache/cache-utils.ts
@@ -1,3 +1,6 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { RedisClient } from 'bullmq';
+
 export namespace CacheUtils {
   export const NUMBER_OF_NONCE_KEYS_TO_CHECK = 50;
   /**
@@ -9,5 +12,17 @@ export namespace CacheUtils {
 
   export function getNonceKey(suffix: string) {
     return `${CHAIN_NONCE_KEY}:${suffix}`;
+  }
+
+  export function redisEventsToEventEmitter(client: RedisClient, eventEmitter: EventEmitter2) {
+    client.on('error', (err) => {
+      eventEmitter.emit('redis.error', err);
+    });
+    client.on('ready', () => {
+      eventEmitter.emit('redis.ready');
+    });
+    client.on('close', () => {
+      eventEmitter.emit('redis.close');
+    });
   }
 }

--- a/src/cache/reconnection-cache.module.ts
+++ b/src/cache/reconnection-cache.module.ts
@@ -1,19 +1,31 @@
-import { RedisModule } from '@liaoliaots/nestjs-redis';
 import { Global, Module } from '@nestjs/common';
+import { EventEmitter2, EventEmitterModule } from '@nestjs/event-emitter';
+import { RedisModule } from '@liaoliaots/nestjs-redis';
 import { ConfigModule } from '#app/config/config.module';
 import { ConfigService } from '#app/config/config.service';
 import { ReconnectionCacheMgrService } from './reconnection-cache-mgr.service';
+import { CacheUtils } from './cache-utils';
 
 @Global()
 @Module({
   imports: [
     RedisModule.forRootAsync(
       {
-        imports: [ConfigModule],
-        useFactory: (configService: ConfigService) => ({
-          config: [{ url: configService.redisUrl.toString() }],
+        imports: [ConfigModule, EventEmitterModule],
+        useFactory: (configService: ConfigService, eventEmitter: EventEmitter2) => ({
+          config: [
+            {
+              url: configService.redisUrl.toString(),
+              maxRetriesPerRequest: null,
+              onClientCreated(client) {
+                CacheUtils.redisEventsToEventEmitter(client, eventEmitter);
+              },
+            },
+          ],
+          readyLog: false,
+          errorLog: false,
         }),
-        inject: [ConfigService],
+        inject: [ConfigService, EventEmitter2],
       },
       false, // isGlobal
     ),

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,10 +29,13 @@ async function bootstrap() {
   });
 
   // eslint-disable-next-line no-undef
-  let redisConnectTimeout: NodeJS.Timeout | null;
+  let redisConnectTimeout: NodeJS.Timeout | null = setTimeout(() => {
+    logger.error('Redis connection timeout!');
+    process.exit(1);
+  }, 30_000);
   eventEmitter.on('redis.ready', () => {
     if (redisConnectTimeout !== null) {
-      logger.warn('Redis Reconnection Detected.');
+      logger.log('Redis Connected!');
       clearTimeout(redisConnectTimeout);
       redisConnectTimeout = null;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ async function bootstrap() {
   });
 
   process.on('uncaughtException', (error) => {
-    console.error(error);
+    console.error('****** UNCAUGHT EXCEPTION ******', error);
     process.exit(1);
   });
   // Get event emitter & register a shutdown listener
@@ -26,6 +26,36 @@ async function bootstrap() {
   eventEmitter.on('shutdown', async () => {
     logger.warn('Received shutdown event');
     await app.close();
+  });
+
+  // eslint-disable-next-line no-undef
+  let redisConnectTimeout: NodeJS.Timeout | null;
+  eventEmitter.on('redis.ready', () => {
+    if (redisConnectTimeout !== null) {
+      logger.warn('Redis Reconnection Detected.');
+      clearTimeout(redisConnectTimeout);
+      redisConnectTimeout = null;
+    }
+  });
+
+  // Note that if redis disconnects Bull Queues will log lots of Error: connect ECONNREFUSED that we cannot stop
+  // This is due to https://github.com/taskforcesh/bullmq/issues/1073
+  eventEmitter.on('redis.close', () => {
+    // Shutdown after a disconnect of more than 30 seconds
+    if (redisConnectTimeout === null) {
+      logger.error('Redis Disconnect Detected! Waiting 30 seconds for reconnection before shutdown.');
+      redisConnectTimeout = setTimeout(() => {
+        logger.error('Redis reconnection timeout!');
+        process.exit(1);
+      }, 30_000);
+    }
+  });
+
+  eventEmitter.on('redis.error', (err: Error) => {
+    // Only log errors if we are not in a connection situation
+    if (redisConnectTimeout === null) {
+      logger.error('Redis Error!', err);
+    }
   });
 
   try {
@@ -36,8 +66,7 @@ async function bootstrap() {
     await app.listen(configService.apiPort);
   } catch (e) {
     await app.close();
-    logger.log('****** MAIN CATCH ********');
-    logger.error(e);
+    logger.error('****** MAIN CATCH ******', e);
     if (e instanceof Error) {
       logger.error(e.stack);
     }
@@ -45,5 +74,5 @@ async function bootstrap() {
 }
 
 bootstrap().catch((err) => {
-  logger.error('Unhandled exception in main', err);
+  logger.error('Unhandled exception in boostrap', err);
 });

--- a/src/processor/graph-update-completion-monitor.service.ts
+++ b/src/processor/graph-update-completion-monitor.service.ts
@@ -4,6 +4,7 @@ import { BlockchainService } from '#app/blockchain/blockchain.service';
 import { BlockchainConstants } from '#app/blockchain/blockchain-constants';
 import { BlockchainScannerService } from '#app/blockchain-scanner.service';
 import { SchedulerRegistry } from '@nestjs/schedule';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { BlockHash, Event } from '@polkadot/types/interfaces';
 import { HexString } from '@polkadot/util/types';
 import { ReconnectionCacheMgrService } from '#app/cache/reconnection-cache-mgr.service';
@@ -40,8 +41,9 @@ export class GraphUpdateCompletionMonitorService extends BlockchainScannerServic
     private readonly schedulerRegistry: SchedulerRegistry,
     blockchainService: BlockchainService,
     private readonly cacheService: ReconnectionCacheMgrService,
+    eventEmitter: EventEmitter2,
   ) {
-    super(cacheManager, blockchainService, new Logger(GraphUpdateCompletionMonitorService.name));
+    super(cacheManager, blockchainService, new Logger(GraphUpdateCompletionMonitorService.name), eventEmitter);
   }
 
   private getTxStatus(txStatus: ITxStatus, hasSuccess: boolean, failureEvent: Event | undefined): ITxStatus {

--- a/src/processor/graph-update-completion-monitor.service.ts
+++ b/src/processor/graph-update-completion-monitor.service.ts
@@ -4,7 +4,6 @@ import { BlockchainService } from '#app/blockchain/blockchain.service';
 import { BlockchainConstants } from '#app/blockchain/blockchain-constants';
 import { BlockchainScannerService } from '#app/blockchain-scanner.service';
 import { SchedulerRegistry } from '@nestjs/schedule';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { BlockHash, Event } from '@polkadot/types/interfaces';
 import { HexString } from '@polkadot/util/types';
 import { ReconnectionCacheMgrService } from '#app/cache/reconnection-cache-mgr.service';
@@ -41,9 +40,8 @@ export class GraphUpdateCompletionMonitorService extends BlockchainScannerServic
     private readonly schedulerRegistry: SchedulerRegistry,
     blockchainService: BlockchainService,
     private readonly cacheService: ReconnectionCacheMgrService,
-    eventEmitter: EventEmitter2,
   ) {
-    super(cacheManager, blockchainService, new Logger(GraphUpdateCompletionMonitorService.name), eventEmitter);
+    super(cacheManager, blockchainService, new Logger(GraphUpdateCompletionMonitorService.name));
   }
 
   private getTxStatus(txStatus: ITxStatus, hasSuccess: boolean, failureEvent: Event | undefined): ITxStatus {

--- a/src/processor/tx-monitor-queue-consumer.service.ts
+++ b/src/processor/tx-monitor-queue-consumer.service.ts
@@ -9,7 +9,6 @@ import { BlockchainConstants } from '#app/blockchain/blockchain-constants';
 import { ReconnectionCacheMgrService } from '#app/cache/reconnection-cache-mgr.service';
 import { ReconnectionServiceConstants } from '#app/constants';
 import { ITxStatus } from '#app/interfaces/tx-status.interface';
-import { Graph } from '@dsnp/graph-sdk';
 
 const CAPACITY_EPOCH_TIMEOUT_NAME = 'capacity_check';
 

--- a/src/reconnection-service.module.ts
+++ b/src/reconnection-service.module.ts
@@ -13,6 +13,7 @@ import { ReconnectionCacheModule } from './cache/reconnection-cache.module';
 
 @Module({
   imports: [
+    ReconnectionCacheModule,
     BullModule,
     ConfigModule,
     EventEmitterModule.forRoot({
@@ -36,7 +37,6 @@ import { ReconnectionCacheModule } from './cache/reconnection-cache.module';
     ScheduleModule.forRoot(),
     ProcessorModule,
     BlockchainModule,
-    ReconnectionCacheModule,
   ],
   providers: [ConfigService, GraphUpdateScannerService],
   controllers: process.env?.ENABLE_DEV_CONTROLLER === 'true' ? [DevelopmentController, ReconnectionServiceController] : [ReconnectionServiceController],


### PR DESCRIPTION
A few things joined to make this happen:
1. Made both redis connection using services use just one redis connection
2. Map redis events to the EventEmitter event stream
3. Setup such that the service will stop with exit code 1, if redis is disconnected for more than 30 seconds.

Things I thought about, but ended up not doing:
- Making the redis timeout an environment variable.
- Doing the same work for the Frequency connection
- Mapping the other Redis events: https://github.com/redis/ioredis/?tab=readme-ov-file#connection-events

How to Test:
- Start Frequency
- Start Redis
- `npm run build && npm run start`
- Stop redis (See logs)
- Start redis (see reconnection)
- Stop redis for more than 30 seconds
- See Exit code


Closes: #78 