### PR TITLE
do not set last seen block on pending tx logic

### DIFF
--- a/src/processor/graph-update-completion-monitor.service.ts
+++ b/src/processor/graph-update-completion-monitor.service.ts
@@ -13,12 +13,12 @@ import * as ReconnectionServiceConstants from '#app/constants';
 @Injectable()
 export class GraphUpdateCompletionMonitorService extends BlockchainScannerService implements OnApplicationBootstrap, OnApplicationShutdown {
   async onApplicationBootstrap() {
-    const pendingTxns = await this.cacheManager.getAllPendingTxns();
+    //const pendingTxns = await this.cacheManager.getAllPendingTxns();
     // If no transactions pending, skip to end of chain at startup
-    if (Object.keys(pendingTxns).length === 0) {
-      const blockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
-      await this.setLastSeenBlockNumber(blockNumber);
-    }
+    // if (Object.keys(pendingTxns).length === 0) {
+    //   const blockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
+    //   await this.setLastSeenBlockNumber(blockNumber);
+    // }
     this.schedulerRegistry.addInterval(
       `${this.constructor.name}:blockchainScan`,
       setInterval(() => this.scan(), BlockchainConstants.SECONDS_PER_BLOCK * MILLISECONDS_PER_SECOND),


### PR DESCRIPTION
## Details,

A bug in how system bootstraped led scanner to move to latest block and ignore any blocks between service start time to current block.

## Tests

- [ ] Run e2e test with a scenario as follow
* Start the chain in interval sealing
* Let some 20-30 empty blocks be formed
* Start frequency scenario for graph migration to create user accounts
* Start re connection service 
* Scanner should be able to go through all blocks and not skip to last one