### PR TITLE
fix: bump graph-sdk to 1.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@bull-board/express": "^5.17.0",
         "@bull-board/nestjs": "^5.17.0",
         "@bull-board/ui": "^5.17.0",
-        "@dsnp/graph-sdk": "^1.1.2",
+        "@dsnp/graph-sdk": "^1.1.3",
         "@frequency-chain/api-augment": "^1.11.1",
         "@nestjs/axios": "^3.0.2",
         "@nestjs/bullmq": "^10.1.1",
@@ -1655,9 +1655,9 @@
       }
     },
     "node_modules/@dsnp/graph-sdk": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@dsnp/graph-sdk/-/graph-sdk-1.1.2.tgz",
-      "integrity": "sha512-B8gOuq4CojsuRhZHsk8oROZ8KBaJ17gd2E3NOHnLr9Ak0wPQs4b1dSHtO9slG8CN/GB6qGhxkb2OgKvdNKx7lw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@dsnp/graph-sdk/-/graph-sdk-1.1.3.tgz",
+      "integrity": "sha512-t/hhGo738BQIYPkfAOWq87tzE2/6Rk/eVdRxWJ5URgLdB8FowNCNWui105Uds5E3dkkjOre/geJbY+McX9caIA==",
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@bull-board/express": "^5.17.0",
     "@bull-board/nestjs": "^5.17.0",
     "@bull-board/ui": "^5.17.0",
-    "@dsnp/graph-sdk": "^1.1.2",
+    "@dsnp/graph-sdk": "^1.1.3",
     "@frequency-chain/api-augment": "^1.11.1",
     "@nestjs/axios": "^3.0.2",
     "@nestjs/bullmq": "^10.1.1",

--- a/setup/testing/package-lock.json
+++ b/setup/testing/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@amplica-labs/frequency-scenario-template": "^1.0.0",
-        "@dsnp/graph-sdk": "^1.1.1",
+        "@dsnp/graph-sdk": "^1.1.3",
         "@frequency-chain/api-augment": "^1.11.1",
         "@polkadot/api-base": "^10.12.4",
         "@polkadot/keyring": "^12.6.2",
@@ -33,7 +33,7 @@
         "@bull-board/express": "^5.17.0",
         "@bull-board/nestjs": "^5.17.0",
         "@bull-board/ui": "^5.17.0",
-        "@dsnp/graph-sdk": "^1.1.2",
+        "@dsnp/graph-sdk": "^1.1.3",
         "@frequency-chain/api-augment": "^1.11.1",
         "@nestjs/axios": "^3.0.2",
         "@nestjs/bullmq": "^10.1.1",
@@ -45,10 +45,10 @@
         "@nestjs/schedule": "^4.0.2",
         "@nestjs/testing": "^10.3.8",
         "@nestjs/typeorm": "^10.0.2",
-        "@polkadot/api": "^11.0.2",
-        "@polkadot/api-base": "^11.0.2",
+        "@polkadot/api": "^10.12.4",
+        "@polkadot/api-base": "^10.12.4",
         "@polkadot/keyring": "^12.6.2",
-        "@polkadot/types": "^11.0.2",
+        "@polkadot/types": "^10.12.4",
         "@polkadot/util": "^12.6.2",
         "@polkadot/util-crypto": "^12.6.2",
         "@songkeys/nestjs-redis": "^10.0.0",
@@ -64,7 +64,6 @@
       "devDependencies": {
         "@eslint/js": "^9.2.0",
         "@jest/globals": "^29.7.0",
-        "@polkadot/typegen": "11.0.2",
         "@types/jest": "^29.5.12",
         "@types/time-constants": "^1.0.2",
         "dotenv": "^16.4.5",
@@ -3523,123 +3522,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "../../node_modules/@polkadot/typegen": {
-      "version": "11.0.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api": "11.0.2",
-        "@polkadot/api-augment": "11.0.2",
-        "@polkadot/rpc-augment": "11.0.2",
-        "@polkadot/rpc-provider": "11.0.2",
-        "@polkadot/types": "11.0.2",
-        "@polkadot/types-augment": "11.0.2",
-        "@polkadot/types-codec": "11.0.2",
-        "@polkadot/types-create": "11.0.2",
-        "@polkadot/types-support": "11.0.2",
-        "@polkadot/util": "^12.6.2",
-        "@polkadot/util-crypto": "^12.6.2",
-        "@polkadot/x-ws": "^12.6.2",
-        "handlebars": "^4.7.8",
-        "tslib": "^2.6.2",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "polkadot-types-chain-info": "scripts/polkadot-types-chain-info.mjs",
-        "polkadot-types-from-chain": "scripts/polkadot-types-from-chain.mjs",
-        "polkadot-types-from-defs": "scripts/polkadot-types-from-defs.mjs",
-        "polkadot-types-internal-interfaces": "scripts/polkadot-types-internal-interfaces.mjs",
-        "polkadot-types-internal-metadata": "scripts/polkadot-types-internal-metadata.mjs"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "../../node_modules/@polkadot/typegen/node_modules/@polkadot-api/json-rpc-provider": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "../../node_modules/@polkadot/typegen/node_modules/@polkadot-api/json-rpc-provider-proxy": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "../../node_modules/@polkadot/typegen/node_modules/@polkadot-api/substrate-client": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "../../node_modules/@polkadot/typegen/node_modules/@polkadot/rpc-provider": {
-      "version": "11.0.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/keyring": "^12.6.2",
-        "@polkadot/types": "11.0.2",
-        "@polkadot/types-support": "11.0.2",
-        "@polkadot/util": "^12.6.2",
-        "@polkadot/util-crypto": "^12.6.2",
-        "@polkadot/x-fetch": "^12.6.2",
-        "@polkadot/x-global": "^12.6.2",
-        "@polkadot/x-ws": "^12.6.2",
-        "eventemitter3": "^5.0.1",
-        "mock-socket": "^9.3.1",
-        "nock": "^13.5.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@substrate/connect": "0.8.10"
-      }
-    },
-    "../../node_modules/@polkadot/typegen/node_modules/@polkadot/types-support": {
-      "version": "11.0.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "../../node_modules/@polkadot/typegen/node_modules/@substrate/connect": {
-      "version": "0.8.10",
-      "dev": true,
-      "license": "GPL-3.0-only",
-      "optional": true,
-      "dependencies": {
-        "@substrate/connect-extension-protocol": "^2.0.0",
-        "@substrate/connect-known-chains": "^1.1.4",
-        "@substrate/light-client-extension-helpers": "^0.0.6",
-        "smoldot": "2.0.22"
-      }
-    },
-    "../../node_modules/@polkadot/typegen/node_modules/@substrate/light-client-extension-helpers": {
-      "version": "0.0.6",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@polkadot-api/json-rpc-provider": "0.0.1",
-        "@polkadot-api/json-rpc-provider-proxy": "0.0.1",
-        "@polkadot-api/observable-client": "0.1.0",
-        "@polkadot-api/substrate-client": "0.0.1",
-        "@substrate/connect-extension-protocol": "^2.0.0",
-        "@substrate/connect-known-chains": "^1.1.4",
-        "rxjs": "^7.8.1"
-      },
-      "peerDependencies": {
-        "smoldot": "2.x"
       }
     },
     "../../node_modules/@polkadot/types": {
@@ -7234,26 +7116,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "../../node_modules/handlebars": {
-      "version": "4.7.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
     "../../node_modules/has-flag": {
       "version": "4.0.0",
       "license": "MIT",
@@ -8730,11 +8592,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "../../node_modules/neo-async": {
-      "version": "2.6.2",
-      "dev": true,
-      "license": "MIT"
     },
     "../../node_modules/no-case": {
       "version": "3.0.4",
@@ -10575,18 +10432,6 @@
         }
       }
     },
-    "../../node_modules/uglify-js": {
-      "version": "3.17.4",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "../../node_modules/uid": {
       "version": "2.0.2",
       "license": "MIT",
@@ -10763,11 +10608,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "../../node_modules/wordwrap": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "../../node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -11749,8 +11589,9 @@
       }
     },
     "node_modules/@dsnp/graph-sdk": {
-      "version": "1.1.1",
-      "license": "Apache-2.0",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@dsnp/graph-sdk/-/graph-sdk-1.1.3.tgz",
+      "integrity": "sha512-t/hhGo738BQIYPkfAOWq87tzE2/6Rk/eVdRxWJ5URgLdB8FowNCNWui105Uds5E3dkkjOre/geJbY+McX9caIA==",
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
       }
@@ -11937,14 +11778,129 @@
         "node": ">=18"
       }
     },
-    "node_modules/@polkadot/api-base": {
+    "node_modules/@polkadot/api-augment/node_modules/@polkadot/api-base": {
       "version": "10.12.6",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.12.6.tgz",
+      "integrity": "sha512-6EzMettffiadB5j0X2nValtrEZJ2dKZMArfWHbSCV1QRSPOaMO3Phf/idqtF8HgBHD3FCHJ+JsZEns6xpkpteg==",
       "dependencies": {
         "@polkadot/rpc-core": "10.12.6",
         "@polkadot/types": "10.12.6",
         "@polkadot/util": "^12.6.2",
         "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-augment/node_modules/@polkadot/types": {
+      "version": "10.12.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.12.6.tgz",
+      "integrity": "sha512-ByjvZkKJclHSWEETk1m9HPYn/IdIyjWONOdy7Ih+/Nd0wVIahvXDYbV4CXe25xO0RhfFJzkGIZP+LFHL5F63Uw==",
+      "dependencies": {
+        "@polkadot/keyring": "^12.6.2",
+        "@polkadot/types-augment": "10.12.6",
+        "@polkadot/types-codec": "10.12.6",
+        "@polkadot/types-create": "10.12.6",
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/util-crypto": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-base": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.13.1.tgz",
+      "integrity": "sha512-Okrw5hjtEjqSMOG08J6qqEwlUQujTVClvY1/eZkzKwNzPelWrtV6vqfyJklB7zVhenlxfxqhZKKcY7zWSW/q5Q==",
+      "dependencies": {
+        "@polkadot/rpc-core": "10.13.1",
+        "@polkadot/types": "10.13.1",
+        "@polkadot/util": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-base/node_modules/@polkadot/rpc-augment": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-10.13.1.tgz",
+      "integrity": "sha512-iLsWUW4Jcx3DOdVrSHtN0biwxlHuTs4QN2hjJV0gd0jo7W08SXhWabZIf9mDmvUJIbR7Vk+9amzvegjRyIf5+A==",
+      "dependencies": {
+        "@polkadot/rpc-core": "10.13.1",
+        "@polkadot/types": "10.13.1",
+        "@polkadot/types-codec": "10.13.1",
+        "@polkadot/util": "^12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-base/node_modules/@polkadot/rpc-core": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-10.13.1.tgz",
+      "integrity": "sha512-eoejSHa+/tzHm0vwic62/aptTGbph8vaBpbvLIK7gd00+rT813ROz5ckB1CqQBFB23nHRLuzzX/toY8ID3xrKw==",
+      "dependencies": {
+        "@polkadot/rpc-augment": "10.13.1",
+        "@polkadot/rpc-provider": "10.13.1",
+        "@polkadot/types": "10.13.1",
+        "@polkadot/util": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-base/node_modules/@polkadot/rpc-provider": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.13.1.tgz",
+      "integrity": "sha512-oJ7tatVXYJ0L7NpNiGd69D558HG5y5ZDmH2Bp9Dd4kFTQIiV8A39SlWwWUPCjSsen9lqSvvprNLnG/VHTpenbw==",
+      "dependencies": {
+        "@polkadot/keyring": "^12.6.2",
+        "@polkadot/types": "10.13.1",
+        "@polkadot/types-support": "10.13.1",
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/util-crypto": "^12.6.2",
+        "@polkadot/x-fetch": "^12.6.2",
+        "@polkadot/x-global": "^12.6.2",
+        "@polkadot/x-ws": "^12.6.2",
+        "eventemitter3": "^5.0.1",
+        "mock-socket": "^9.3.1",
+        "nock": "^13.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@substrate/connect": "0.8.8"
+      }
+    },
+    "node_modules/@polkadot/api-base/node_modules/@polkadot/types-codec": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.13.1.tgz",
+      "integrity": "sha512-AiQ2Vv2lbZVxEdRCN8XSERiWlOWa2cTDLnpAId78EnCtx4HLKYQSd+Jk9Y4BgO35R79mchK4iG+w6gZ+ukG2bg==",
+      "dependencies": {
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/x-bigint": "^12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-base/node_modules/@polkadot/types-support": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.13.1.tgz",
+      "integrity": "sha512-4gEPfz36XRQIY7inKq0HXNVVhR6HvXtm7yrEmuBuhM86LE0lQQBkISUSgR358bdn2OFSLMxMoRNoh3kcDvdGDQ==",
+      "dependencies": {
+        "@polkadot/util": "^12.6.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11961,6 +11917,72 @@
         "@polkadot/rpc-core": "10.12.6",
         "@polkadot/types": "10.12.6",
         "@polkadot/types-codec": "10.12.6",
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/util-crypto": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-derive/node_modules/@polkadot/api-base": {
+      "version": "10.12.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.12.6.tgz",
+      "integrity": "sha512-6EzMettffiadB5j0X2nValtrEZJ2dKZMArfWHbSCV1QRSPOaMO3Phf/idqtF8HgBHD3FCHJ+JsZEns6xpkpteg==",
+      "dependencies": {
+        "@polkadot/rpc-core": "10.12.6",
+        "@polkadot/types": "10.12.6",
+        "@polkadot/util": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-derive/node_modules/@polkadot/types": {
+      "version": "10.12.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.12.6.tgz",
+      "integrity": "sha512-ByjvZkKJclHSWEETk1m9HPYn/IdIyjWONOdy7Ih+/Nd0wVIahvXDYbV4CXe25xO0RhfFJzkGIZP+LFHL5F63Uw==",
+      "dependencies": {
+        "@polkadot/keyring": "^12.6.2",
+        "@polkadot/types-augment": "10.12.6",
+        "@polkadot/types-codec": "10.12.6",
+        "@polkadot/types-create": "10.12.6",
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/util-crypto": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api/node_modules/@polkadot/api-base": {
+      "version": "10.12.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.12.6.tgz",
+      "integrity": "sha512-6EzMettffiadB5j0X2nValtrEZJ2dKZMArfWHbSCV1QRSPOaMO3Phf/idqtF8HgBHD3FCHJ+JsZEns6xpkpteg==",
+      "dependencies": {
+        "@polkadot/rpc-core": "10.12.6",
+        "@polkadot/types": "10.12.6",
+        "@polkadot/util": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api/node_modules/@polkadot/types": {
+      "version": "10.12.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.12.6.tgz",
+      "integrity": "sha512-ByjvZkKJclHSWEETk1m9HPYn/IdIyjWONOdy7Ih+/Nd0wVIahvXDYbV4CXe25xO0RhfFJzkGIZP+LFHL5F63Uw==",
+      "dependencies": {
+        "@polkadot/keyring": "^12.6.2",
+        "@polkadot/types-augment": "10.12.6",
+        "@polkadot/types-codec": "10.12.6",
+        "@polkadot/types-create": "10.12.6",
         "@polkadot/util": "^12.6.2",
         "@polkadot/util-crypto": "^12.6.2",
         "rxjs": "^7.8.1",
@@ -12012,6 +12034,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/types": {
+      "version": "10.12.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.12.6.tgz",
+      "integrity": "sha512-ByjvZkKJclHSWEETk1m9HPYn/IdIyjWONOdy7Ih+/Nd0wVIahvXDYbV4CXe25xO0RhfFJzkGIZP+LFHL5F63Uw==",
+      "dependencies": {
+        "@polkadot/keyring": "^12.6.2",
+        "@polkadot/types-augment": "10.12.6",
+        "@polkadot/types-codec": "10.12.6",
+        "@polkadot/types-create": "10.12.6",
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/util-crypto": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@polkadot/rpc-core": {
       "version": "10.12.6",
       "license": "Apache-2.0",
@@ -12020,6 +12060,24 @@
         "@polkadot/rpc-provider": "10.12.6",
         "@polkadot/types": "10.12.6",
         "@polkadot/util": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-core/node_modules/@polkadot/types": {
+      "version": "10.12.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.12.6.tgz",
+      "integrity": "sha512-ByjvZkKJclHSWEETk1m9HPYn/IdIyjWONOdy7Ih+/Nd0wVIahvXDYbV4CXe25xO0RhfFJzkGIZP+LFHL5F63Uw==",
+      "dependencies": {
+        "@polkadot/keyring": "^12.6.2",
+        "@polkadot/types-augment": "10.12.6",
+        "@polkadot/types-codec": "10.12.6",
+        "@polkadot/types-create": "10.12.6",
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/util-crypto": "^12.6.2",
         "rxjs": "^7.8.1",
         "tslib": "^2.6.2"
       },
@@ -12051,14 +12109,33 @@
         "@substrate/connect": "0.8.8"
       }
     },
-    "node_modules/@polkadot/types": {
+    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/types": {
       "version": "10.12.6",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.12.6.tgz",
+      "integrity": "sha512-ByjvZkKJclHSWEETk1m9HPYn/IdIyjWONOdy7Ih+/Nd0wVIahvXDYbV4CXe25xO0RhfFJzkGIZP+LFHL5F63Uw==",
       "dependencies": {
         "@polkadot/keyring": "^12.6.2",
         "@polkadot/types-augment": "10.12.6",
         "@polkadot/types-codec": "10.12.6",
         "@polkadot/types-create": "10.12.6",
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/util-crypto": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.13.1.tgz",
+      "integrity": "sha512-Hfvg1ZgJlYyzGSAVrDIpp3vullgxrjOlh/CSThd/PI4TTN1qHoPSFm2hs77k3mKkOzg+LrWsLE0P/LP2XddYcw==",
+      "dependencies": {
+        "@polkadot/keyring": "^12.6.2",
+        "@polkadot/types-augment": "10.13.1",
+        "@polkadot/types-codec": "10.13.1",
+        "@polkadot/types-create": "10.13.1",
         "@polkadot/util": "^12.6.2",
         "@polkadot/util-crypto": "^12.6.2",
         "rxjs": "^7.8.1",
@@ -12075,6 +12152,24 @@
         "@polkadot/types": "10.12.6",
         "@polkadot/types-codec": "10.12.6",
         "@polkadot/util": "^12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-augment/node_modules/@polkadot/types": {
+      "version": "10.12.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.12.6.tgz",
+      "integrity": "sha512-ByjvZkKJclHSWEETk1m9HPYn/IdIyjWONOdy7Ih+/Nd0wVIahvXDYbV4CXe25xO0RhfFJzkGIZP+LFHL5F63Uw==",
+      "dependencies": {
+        "@polkadot/keyring": "^12.6.2",
+        "@polkadot/types-augment": "10.12.6",
+        "@polkadot/types-codec": "10.12.6",
+        "@polkadot/types-create": "10.12.6",
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/util-crypto": "^12.6.2",
+        "rxjs": "^7.8.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12120,10 +12215,68 @@
         "node": ">=18"
       }
     },
+    "node_modules/@polkadot/types-known/node_modules/@polkadot/types": {
+      "version": "10.12.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.12.6.tgz",
+      "integrity": "sha512-ByjvZkKJclHSWEETk1m9HPYn/IdIyjWONOdy7Ih+/Nd0wVIahvXDYbV4CXe25xO0RhfFJzkGIZP+LFHL5F63Uw==",
+      "dependencies": {
+        "@polkadot/keyring": "^12.6.2",
+        "@polkadot/types-augment": "10.12.6",
+        "@polkadot/types-codec": "10.12.6",
+        "@polkadot/types-create": "10.12.6",
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/util-crypto": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@polkadot/types-support": {
       "version": "10.12.6",
       "license": "Apache-2.0",
       "dependencies": {
+        "@polkadot/util": "^12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types/node_modules/@polkadot/types-augment": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.13.1.tgz",
+      "integrity": "sha512-TcrLhf95FNFin61qmVgOgayzQB/RqVsSg9thAso1Fh6pX4HSbvI35aGPBAn3SkA6R+9/TmtECirpSNLtIGFn0g==",
+      "dependencies": {
+        "@polkadot/types": "10.13.1",
+        "@polkadot/types-codec": "10.13.1",
+        "@polkadot/util": "^12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types/node_modules/@polkadot/types-codec": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.13.1.tgz",
+      "integrity": "sha512-AiQ2Vv2lbZVxEdRCN8XSERiWlOWa2cTDLnpAId78EnCtx4HLKYQSd+Jk9Y4BgO35R79mchK4iG+w6gZ+ukG2bg==",
+      "dependencies": {
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/x-bigint": "^12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types/node_modules/@polkadot/types-create": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.13.1.tgz",
+      "integrity": "sha512-Usn1jqrz35SXgCDAqSXy7mnD6j4RvB4wyzTAZipFA6DGmhwyxxIgOzlWQWDb+1PtPKo9vtMzen5IJ+7w5chIeA==",
+      "dependencies": {
+        "@polkadot/types-codec": "10.13.1",
         "@polkadot/util": "^12.6.2",
         "tslib": "^2.6.2"
       },
@@ -13004,8 +13157,9 @@
       "optional": true
     },
     "node_modules/@substrate/connect-known-chains": {
-      "version": "1.1.2",
-      "license": "GPL-3.0-only",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-known-chains/-/connect-known-chains-1.1.5.tgz",
+      "integrity": "sha512-GCdDMs5q9xDYyP/KEwrlWMdqv8OIPjuVMZvNowvUrvEFo5d+x+VqfRPzyl/RbV+snRQVWTTacRydE7GqyjCYPQ==",
       "optional": true
     },
     "node_modules/@substrate/light-client-extension-helpers": {

--- a/setup/testing/package.json
+++ b/setup/testing/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@dsnp/graph-sdk": "^1.1.1",
+    "@dsnp/graph-sdk": "^1.1.3",
     "@frequency-chain/api-augment": "^1.11.1",
     "@polkadot/api-base": "^10.12.4",
     "@polkadot/keyring": "^12.6.2",


### PR DESCRIPTION
# Description
Bump `graph-sdk` dependency to `1.1.3` for 32-page limits in user graphs.

# **WARNING** do not merge until:
* [x] Mainnet runtime upgraded to `1.12.0`
* [x] `graph-sdk` `1.1.3` release
* [x] PR updated `package-lock.json` after new graph-sdk package available